### PR TITLE
`reachTarget` command line option to use meanpayoff for reachability

### DIFF
--- a/.run/consensus.2-rewards disagree.run.xml
+++ b/.run/consensus.2-rewards disagree.run.xml
@@ -4,7 +4,7 @@
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="de.tum.in.pet.Main" />
     <module name="partial-exploration.main" />
-    <option name="PROGRAM_PARAMETERS" value="meanPayoff -m data/mdpReachRewardModels/consensus/consensus.2-rewards.prism -c K=2 -pMin 0.1083 --informationLevel BLACKBOX --rewardModule disagree --maxReward 1 --alpha 0.6" />
+    <option name="PROGRAM_PARAMETERS" value="meanPayoff -m data/mdpReachRewardModels/consensus/consensus.2-rewards.prism -c K=2 -pMin 0.1083 --informationLevel BLACKBOX --rewardModule disagree --maxReward 1 --alpha 0.6 --reachTarget target" />
     <option name="VM_PARAMETERS" value="-ea" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.run/csma.2-2-rewards some_before.run.xml
+++ b/.run/csma.2-2-rewards some_before.run.xml
@@ -4,7 +4,7 @@
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="de.tum.in.pet.Main" />
     <module name="partial-exploration.main" />
-    <option name="PROGRAM_PARAMETERS" value="meanPayoff -m data/mdpReachRewardModels/csma/csma.2-2-rewards.prism -c MAXSTEPS=5 -pMin 0.25 --informationLevel BLACKBOX --rewardModule some_before --maxReward 1 --alpha 0.6" />
+    <option name="PROGRAM_PARAMETERS" value="meanPayoff -m data/mdpReachRewardModels/csma/csma.2-2-rewards.prism -c MAXSTEPS=5 -pMin 0.25 --informationLevel BLACKBOX --rewardModule some_before --maxReward 1 --alpha 0.6 --reachTarget target" />
     <option name="VM_PARAMETERS" value="-ea" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.run/pacman-rewards crash.run.xml
+++ b/.run/pacman-rewards crash.run.xml
@@ -4,7 +4,7 @@
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="de.tum.in.pet.Main" />
     <module name="partial-exploration.main" />
-    <option name="PROGRAM_PARAMETERS" value="meanPayoff -m data/mdpReachRewardModels/pacman/pacman-rewards.prism -c MAXSTEPS=5 -pMin 0.08 --informationLevel BLACKBOX --rewardModule crash --maxReward 1 --alpha 0.6" />
+    <option name="PROGRAM_PARAMETERS" value="meanPayoff -m data/mdpReachRewardModels/pacman/pacman-rewards.prism -c MAXSTEPS=5 -pMin 0.08 --informationLevel BLACKBOX --rewardModule crash --maxReward 1 --alpha 0.6 --reachTarget target" />
     <option name="VM_PARAMETERS" value="-ea" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.run/pnueli-zuck.3-rewards live.run.xml
+++ b/.run/pnueli-zuck.3-rewards live.run.xml
@@ -4,7 +4,7 @@
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="de.tum.in.pet.Main" />
     <module name="partial-exploration.main" />
-    <option name="PROGRAM_PARAMETERS" value="meanPayoff -m data/mdpReachRewardModels/pnueli-zuck-3/pnueli-zuck.3-rewards.prism -pMin 0.5 --informationLevel BLACKBOX --rewardModule live --maxReward 1 --alpha 0.6" />
+    <option name="PROGRAM_PARAMETERS" value="meanPayoff -m data/mdpReachRewardModels/pnueli-zuck-3/pnueli-zuck.3-rewards.prism -pMin 0.5 --informationLevel BLACKBOX --rewardModule live --maxReward 1 --alpha 0.6 --reachTarget target" />
     <option name="VM_PARAMETERS" value="-ea" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.run/rabin.3-rewards live.run.xml
+++ b/.run/rabin.3-rewards live.run.xml
@@ -4,7 +4,7 @@
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="de.tum.in.pet.Main" />
     <module name="partial-exploration.main" />
-    <option name="PROGRAM_PARAMETERS" value="meanPayoff -m data/mdpReachRewardModels/rabin-3/rabin.3-rewards.prism -pMin 0.03125 --informationLevel BLACKBOX --rewardModule live --maxReward 1 --alpha 0.6" />
+    <option name="PROGRAM_PARAMETERS" value="meanPayoff -m data/mdpReachRewardModels/rabin-3/rabin.3-rewards.prism -pMin 0.03125 --informationLevel BLACKBOX --rewardModule live --maxReward 1 --alpha 0.6 --reachTarget target" />
     <option name="VM_PARAMETERS" value="-ea" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.run/wlan.0-rewards sent.run.xml
+++ b/.run/wlan.0-rewards sent.run.xml
@@ -4,7 +4,7 @@
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="de.tum.in.pet.Main" />
     <module name="partial-exploration.main" />
-    <option name="PROGRAM_PARAMETERS" value="meanPayoff -m data/mdpReachRewardModels/wlan-0/wlan.0-rewards.prism -c COL=0 -pMin 0.0625 --informationLevel BLACKBOX --rewardModule sent --maxReward 1 --alpha 0.6" />
+    <option name="PROGRAM_PARAMETERS" value="meanPayoff -m data/mdpReachRewardModels/wlan-0/wlan.0-rewards.prism -c COL=0 -pMin 0.0625 --informationLevel BLACKBOX --rewardModule sent --maxReward 1 --alpha 0.6 --reachTarget target" />
     <option name="VM_PARAMETERS" value="-ea" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.run/zeroconf-rewards correct_max.run.xml
+++ b/.run/zeroconf-rewards correct_max.run.xml
@@ -4,7 +4,7 @@
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="de.tum.in.pet.Main" />
     <module name="partial-exploration.main" />
-    <option name="PROGRAM_PARAMETERS" value="meanPayoff -m data/mdpReachRewardModels/zeroconf/zeroconf-rewards.prism -pMin 0.0002 -c N=40,K=10,reset=false --informationLevel BLACKBOX --rewardModule correct_max --maxReward 1 --alpha 0.6" />
+    <option name="PROGRAM_PARAMETERS" value="meanPayoff -m data/mdpReachRewardModels/zeroconf/zeroconf-rewards.prism -pMin 0.0002 -c N=40,K=10,reset=false --informationLevel BLACKBOX --rewardModule correct_max --maxReward 1 --alpha 0.6 --reachTarget target" />
     <option name="VM_PARAMETERS" value="-ea" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/src/main/java/de/tum/in/pet/Input/InputOptions.java
+++ b/src/main/java/de/tum/in/pet/Input/InputOptions.java
@@ -27,6 +27,7 @@ public class InputOptions {
     public static Option maxSuccessorOption = new Option(null, "maxSuccessors", true, "Maximum number of successors in model");
     public static Option deltaTOption = new Option(null, "deltaTMethod", true, "Computation method of Delta T");
     public static Option alphaOption = new Option(null, "alpha", true, "Optimization for whether to explore best action or uncertain action");
+    public static Option reachTarget = new Option(null, "reachTarget", true, "Target state's label");
 
     public static Options getAllInputOptions() {
         modelOption.setRequired(true);
@@ -51,6 +52,7 @@ public class InputOptions {
                 .addOption(outputFile)
                 .addOption(maxSuccessorOption)
                 .addOption(deltaTOption)
-                .addOption(alphaOption);
+                .addOption(alphaOption)
+                .addOption(reachTarget);
     }
 }

--- a/src/main/java/de/tum/in/pet/Input/InputParser.java
+++ b/src/main/java/de/tum/in/pet/Input/InputParser.java
@@ -51,6 +51,8 @@ public class InputParser {
                 commandLine.getOptionValue(InputOptions.deltaTOption.getLongOpt()), DefaultInputValues.DELTA_T_CALCULATION_METHOD);
         double alpha = parseDoubleOption(commandLine, InputOptions.alphaOption, DefaultInputValues.ALPHA);
 
+        String reachTargetLabel = parseOption(commandLine, InputOptions.reachTarget, "", Function.identity());
+
         return new InputValues(precision,
                 revisitThreshold,
                 maxReward,
@@ -68,7 +70,8 @@ public class InputParser {
                 outputPath,
                 maxSuccessorsInModel,
                 deltaTMethod,
-                alpha);
+                alpha,
+                reachTargetLabel);
     }
 
     private static long parseLongOption(CommandLine commandLine, Option option, long defaultValue) {

--- a/src/main/java/de/tum/in/pet/Input/InputValues.java
+++ b/src/main/java/de/tum/in/pet/Input/InputValues.java
@@ -25,12 +25,14 @@ public class InputValues {
     public final int maxSuccessorsInModel;
     public final DeltaTCalculationMethod deltaTCalculationMethod;
     public final double alpha;
+    public final String reachTargetLabel;
 
 
     public InputValues(double precision, int revisitThreshold, double maxReward, double pMin, double errorTolerance,
                        int iterSamples, long timeout, boolean getErrorProbability, SuccessorHeuristic successorHeuristic,
                        InformationLevel informationLevel, UpdateMethod updateMethod, String rewardStructure, boolean solveUsingQP,
-                       SimulateMec simulateMec, String outputPath, int maxSuccessorsInModel, DeltaTCalculationMethod deltaTCalculationMethod, double alpha) {
+                       SimulateMec simulateMec, String outputPath, int maxSuccessorsInModel, DeltaTCalculationMethod deltaTCalculationMethod,
+                       double alpha, String reachTargetLabel) {
         this.precision = precision;
         this.revisitThreshold = revisitThreshold;
         this.maxReward = maxReward;
@@ -49,5 +51,6 @@ public class InputValues {
         this.maxSuccessorsInModel = maxSuccessorsInModel;
         this.deltaTCalculationMethod = deltaTCalculationMethod;
         this.alpha = alpha;
+        this.reachTargetLabel = reachTargetLabel;
     }
 }

--- a/src/main/java/de/tum/in/pet/implementation/meanPayoff/MeanPayoffChecker.java
+++ b/src/main/java/de/tum/in/pet/implementation/meanPayoff/MeanPayoffChecker.java
@@ -175,7 +175,12 @@ public final class MeanPayoffChecker {
           throws PrismException {
 
     MarkovDecisionProcess partialModel = new MarkovDecisionProcess();
-    Generator<State> generator = new MdpGenerator(prismGenerator);
+
+    Generator<State> generator;
+    if (inputValues.reachTargetLabel.isEmpty())
+      generator = new MdpGenerator(prismGenerator, inputValues.reachTargetLabel);
+    else
+      generator = new MdpGenerator(prismGenerator);
 
     RewardGenerator<State> rewardGenerator = new PrismRewardGenerator(rewardIndex, prismGenerator);
 


### PR DESCRIPTION
To use the normal mean-payoff, you will run
```bash
meanPayoff -m data/models/zeroconf_rewards.prism --precision 0.01 --maxReward 1 --revisitThreshold 2 -c N=40,K=10,reset=false --rewardModule avoid
```

To use reach-checker with mean-payoff, you will run
```bash
meanPayoff -m data/mdpReachRewardModels/zeroconf/zeroconf-rewards.prism -pMin 0.0002 -c N=40,K=10,reset=false --informationLevel BLACKBOX --rewardModule correct_max --maxReward 1 --alpha 0.6 --reachTarget target
```
> additional `--reachTarget <target state label>` flag

This PR depends on pazhamalai/probabilistic-models#1. Can merge this after that PR is merged.
Also please **do not merge** it immediately after merging the previously mentioned PR, I will need to make 1 more commit updating the submodule.